### PR TITLE
Avoid using HTML encoded version of the JSON

### DIFF
--- a/JSONView.safariextension/js/inject.js
+++ b/JSONView.safariextension/js/inject.js
@@ -2,10 +2,10 @@
 
 let json = null;
 if (document.body.getElementsByTagName("*").length === 1 && document.body.getElementsByTagName("pre").length === 1)
-	json = parseJSON(document.body.getElementsByTagName("pre")[0].innerHTML);
+	json = parseJSON(document.body.getElementsByTagName("pre")[0].textContent);
 
 if (!json)
-	json = parseJSON(document.body.innerHTML);
+	json = parseJSON(document.body.textContent);
 
 if (json) {
 	document.body.textContent = "";


### PR DESCRIPTION
By reading out `innerHTML` we get escaped entities for HTML special character like: & < >
`textContent` gives us the raw text from the JSON.

Example of the problem:
![screen shot 2018-05-09 at 08 49 57](https://user-images.githubusercontent.com/5422/39799962-70a02300-5366-11e8-83c8-2b14c19460b1.png)
